### PR TITLE
Updating links (tech blog + jobs search)

### DIFF
--- a/profile/README.md
+++ b/profile/README.md
@@ -4,7 +4,7 @@
 
 eBay is a global commerce leader which empowers people and creates economic
 opportunity. We publish open source code to share technical artifacts with the
-broader community and publish [a tech blog](https://tech.ebayinc.com/) to share
+broader community and publish [a tech blog](https://innovation.ebayinc.com/tech/) to share
 our experiences.
 
 If you're hoping to build integrations with eBay using our open source toolkit,
@@ -14,4 +14,4 @@ In order to provide an inclusive environment, we adhere to a [code of
 conduct](https://github.com/eBay/.github/blob/main/CODE_OF_CONDUCT.md).
 
 If you're interested in joining eBay and working with open source, check out
-[our open source jobs](https://jobs.ebayinc.com/search-jobs?k=open+source).
+[our open source jobs](https://jobs.ebayinc.com/us/en/search-results?keywords=open%20source).


### PR DESCRIPTION
Few minor link updates.

* Updating link to tech blog: Used to be `tech.ebayinc.com`, now lives under a new domain at https://innovation.ebayinc.com/tech/
* The URL to search jobs has changed. The link to open source jobs should now go to: https://jobs.ebayinc.com/us/en/search-results?keywords=open%20source

Please feel free to reach out to me if more details are needed!