### PR TITLE
Minor: Ensure job search uses quotes to capture the correct job openings (phrase search vs "or" search)

### DIFF
--- a/profile/README.md
+++ b/profile/README.md
@@ -14,4 +14,4 @@ In order to provide an inclusive environment, we adhere to a [code of
 conduct](https://github.com/eBay/.github/blob/main/CODE_OF_CONDUCT.md).
 
 If you're interested in joining eBay and working with open source, check out
-[our open source jobs](https://jobs.ebayinc.com/us/en/search-results?keywords=open%20source).
+[our open source jobs](https://jobs.ebayinc.com/us/en/search-results?keywords=%22open%20source%22).


### PR DESCRIPTION
Sorry @Swathi-L, quick fix.

The jobs search should be using quotes in the search phrase in order to properly capture open source jobs. 

i.e. https://jobs.ebayinc.com/us/en/search-results?keywords=%22open%20source%22

vs. the current https://jobs.ebayinc.com/us/en/search-results?keywords=open%20source 

Please LMK if you have any questions.